### PR TITLE
Fix newly-generic Uint8Array in TypeScript 5.7

### DIFF
--- a/.github/workflows/ciChecks.yml
+++ b/.github/workflows/ciChecks.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: ["v2.1.x"]
+        deno-version: ["v2.1.x", "v2.2.x"]
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/server/src/cose.ts
+++ b/packages/server/src/cose.ts
@@ -1,5 +1,7 @@
 import type { CBORType } from '@levischuck/tiny-cbor';
 
+import type { Uint8Array_ } from './helpers/types.ts';
+
 /**
  * Fundamental values that are needed to discern the more specific COSE public key types below.
  *
@@ -30,10 +32,10 @@ export type COSEPublicKey = {
 export type COSEPublicKeyOKP = COSEPublicKey & {
   // Getters
   get(key: COSEKEYS.crv): number | undefined;
-  get(key: COSEKEYS.x): Uint8Array<ArrayBuffer> | undefined;
+  get(key: COSEKEYS.x): Uint8Array_ | undefined;
   // Setters
   set(key: COSEKEYS.crv, value: number): void;
-  set(key: COSEKEYS.x, value: Uint8Array<ArrayBuffer>): void;
+  set(key: COSEKEYS.x, value: Uint8Array_): void;
 };
 
 /**
@@ -42,12 +44,12 @@ export type COSEPublicKeyOKP = COSEPublicKey & {
 export type COSEPublicKeyEC2 = COSEPublicKey & {
   // Getters
   get(key: COSEKEYS.crv): number | undefined;
-  get(key: COSEKEYS.x): Uint8Array<ArrayBuffer> | undefined;
-  get(key: COSEKEYS.y): Uint8Array<ArrayBuffer> | undefined;
+  get(key: COSEKEYS.x): Uint8Array_ | undefined;
+  get(key: COSEKEYS.y): Uint8Array_ | undefined;
   // Setters
   set(key: COSEKEYS.crv, value: number): void;
-  set(key: COSEKEYS.x, value: Uint8Array<ArrayBuffer>): void;
-  set(key: COSEKEYS.y, value: Uint8Array<ArrayBuffer>): void;
+  set(key: COSEKEYS.x, value: Uint8Array_): void;
+  set(key: COSEKEYS.y, value: Uint8Array_): void;
 };
 
 /**
@@ -55,11 +57,11 @@ export type COSEPublicKeyEC2 = COSEPublicKey & {
  */
 export type COSEPublicKeyRSA = COSEPublicKey & {
   // Getters
-  get(key: COSEKEYS.n): Uint8Array<ArrayBuffer> | undefined;
-  get(key: COSEKEYS.e): Uint8Array<ArrayBuffer> | undefined;
+  get(key: COSEKEYS.n): Uint8Array_ | undefined;
+  get(key: COSEKEYS.e): Uint8Array_ | undefined;
   // Setters
-  set(key: COSEKEYS.n, value: Uint8Array<ArrayBuffer>): void;
-  set(key: COSEKEYS.e, value: Uint8Array<ArrayBuffer>): void;
+  set(key: COSEKEYS.n, value: Uint8Array_): void;
+  set(key: COSEKEYS.e, value: Uint8Array_): void;
 };
 
 /**
@@ -204,8 +206,8 @@ export type COSESign1<
 ];
 export type COSESign1HeaderProtected = CBORType;
 export type COSESign1HeaderUnprotected = Map<string | number, CBORType>;
-export type COSESign1Payload = Uint8Array<ArrayBuffer> | undefined;
-export type COSESign1Signature = Uint8Array<ArrayBuffer>;
+export type COSESign1Payload = Uint8Array_ | undefined;
+export type COSESign1Signature = Uint8Array_;
 
 /**
  * COSE_X509
@@ -223,4 +225,4 @@ export type CBORX5Chain = {
  *
  * mdoc B.1.1 says X.509 chain certs are DER-encoded
  */
-export type COSEX509DERBytes = Uint8Array<ArrayBuffer>;
+export type COSEX509DERBytes = Uint8Array_;

--- a/packages/server/src/cose.ts
+++ b/packages/server/src/cose.ts
@@ -30,10 +30,10 @@ export type COSEPublicKey = {
 export type COSEPublicKeyOKP = COSEPublicKey & {
   // Getters
   get(key: COSEKEYS.crv): number | undefined;
-  get(key: COSEKEYS.x): Uint8Array | undefined;
+  get(key: COSEKEYS.x): Uint8Array<ArrayBuffer> | undefined;
   // Setters
   set(key: COSEKEYS.crv, value: number): void;
-  set(key: COSEKEYS.x, value: Uint8Array): void;
+  set(key: COSEKEYS.x, value: Uint8Array<ArrayBuffer>): void;
 };
 
 /**
@@ -42,12 +42,12 @@ export type COSEPublicKeyOKP = COSEPublicKey & {
 export type COSEPublicKeyEC2 = COSEPublicKey & {
   // Getters
   get(key: COSEKEYS.crv): number | undefined;
-  get(key: COSEKEYS.x): Uint8Array | undefined;
-  get(key: COSEKEYS.y): Uint8Array | undefined;
+  get(key: COSEKEYS.x): Uint8Array<ArrayBuffer> | undefined;
+  get(key: COSEKEYS.y): Uint8Array<ArrayBuffer> | undefined;
   // Setters
   set(key: COSEKEYS.crv, value: number): void;
-  set(key: COSEKEYS.x, value: Uint8Array): void;
-  set(key: COSEKEYS.y, value: Uint8Array): void;
+  set(key: COSEKEYS.x, value: Uint8Array<ArrayBuffer>): void;
+  set(key: COSEKEYS.y, value: Uint8Array<ArrayBuffer>): void;
 };
 
 /**
@@ -55,11 +55,11 @@ export type COSEPublicKeyEC2 = COSEPublicKey & {
  */
 export type COSEPublicKeyRSA = COSEPublicKey & {
   // Getters
-  get(key: COSEKEYS.n): Uint8Array | undefined;
-  get(key: COSEKEYS.e): Uint8Array | undefined;
+  get(key: COSEKEYS.n): Uint8Array<ArrayBuffer> | undefined;
+  get(key: COSEKEYS.e): Uint8Array<ArrayBuffer> | undefined;
   // Setters
-  set(key: COSEKEYS.n, value: Uint8Array): void;
-  set(key: COSEKEYS.e, value: Uint8Array): void;
+  set(key: COSEKEYS.n, value: Uint8Array<ArrayBuffer>): void;
+  set(key: COSEKEYS.e, value: Uint8Array<ArrayBuffer>): void;
 };
 
 /**
@@ -204,8 +204,8 @@ export type COSESign1<
 ];
 export type COSESign1HeaderProtected = CBORType;
 export type COSESign1HeaderUnprotected = Map<string | number, CBORType>;
-export type COSESign1Payload = Uint8Array | undefined;
-export type COSESign1Signature = Uint8Array;
+export type COSESign1Payload = Uint8Array<ArrayBuffer> | undefined;
+export type COSESign1Signature = Uint8Array<ArrayBuffer>;
 
 /**
  * COSE_X509
@@ -223,4 +223,4 @@ export type CBORX5Chain = {
  *
  * mdoc B.1.1 says X.509 chain certs are DER-encoded
  */
-export type COSEX509DERBytes = Uint8Array;
+export type COSEX509DERBytes = Uint8Array<ArrayBuffer>;

--- a/packages/server/src/formats/mdoc/types.ts
+++ b/packages/server/src/formats/mdoc/types.ts
@@ -7,6 +7,7 @@ import type {
   COSEPublicKeyEC2,
   COSEPublicKeyOKP,
 } from '../../cose.ts';
+import type { Uint8Array_ } from '../../helpers/types.ts';
 
 /**
  * 7.1 mDL document type and namespace
@@ -66,7 +67,7 @@ export type IssuerAuth = COSESign1<
   MobileSecurityObjectBytes
 >;
 
-export type MdocIssuerAuthProtectedBytes = Uint8Array<ArrayBuffer>;
+export type MdocIssuerAuthProtectedBytes = Uint8Array_;
 export type MdocIssuerAuthProtected = {
   /**
    * From mdoc 9.1.3.6:
@@ -79,7 +80,7 @@ export type MdocIssuerAuthProtected = {
   ): COSEALG.ES256 | COSEALG.ES384 | COSEALG.ES512 | COSEALG.EdDSA;
 };
 
-export type MdocDeviceAuthProtectedBytes = Uint8Array<ArrayBuffer>;
+export type MdocDeviceAuthProtectedBytes = Uint8Array_;
 export type MdocDeviceAuthProtected = {
   /**
    * From mdoc 9.1.3.6:
@@ -92,7 +93,7 @@ export type MdocDeviceAuthProtected = {
   ): COSEALG.ES256 | COSEALG.ES384 | COSEALG.ES512 | COSEALG.EdDSA;
 };
 
-export type MobileSecurityObjectBytes = Uint8Array<ArrayBuffer>;
+export type MobileSecurityObjectBytes = Uint8Array_;
 export type MobileSecurityObject = {
   get(key: 'version'): string; // Version of the MobileSecurityObject
   get(key: 'digestAlgorithm'): 'SHA-256' | 'SHA-384' | 'SHA-512'; // Message digest algorithm used
@@ -108,7 +109,7 @@ export type ValidityInfo = {
   get(key: 'validUntil'): CBORTag;
 };
 
-export type ValueDigests = Map<string, Map<number, Uint8Array<ArrayBuffer>>>;
+export type ValueDigests = Map<string, Map<number, Uint8Array_>>;
 
 /**  */
 export type DeviceKeyInfo = {
@@ -127,7 +128,7 @@ export type AuthorizedDataElements = unknown; // Spec type: `{+ NameSpace => Dat
 
 export type DecodedIssuerSignedItem = {
   get(key: 'digestID'): number;
-  get(key: 'random'): Uint8Array<ArrayBuffer>;
+  get(key: 'random'): Uint8Array_;
   get(key: 'elementIdentifier'): string;
   get(key: 'elementValue'): unknown; // Necessarily undefinable here
 };
@@ -175,8 +176,8 @@ export type COSESign1<
 ];
 export type COSESign1HeaderProtected = CBORType;
 export type COSESign1HeaderUnprotected = Map<string | number, CBORType>;
-export type COSESign1Payload = Uint8Array<ArrayBuffer> | undefined;
-export type COSESign1Signature = Uint8Array<ArrayBuffer>;
+export type COSESign1Payload = Uint8Array_ | undefined;
+export type COSESign1Signature = Uint8Array_;
 
 /**
  * Sig_structure
@@ -190,10 +191,10 @@ export type COSESign1Signature = Uint8Array<ArrayBuffer>;
  */
 export type COSESign1SigStructure = [
   context: 'Signature1',
-  body_protected: Uint8Array<ArrayBuffer>,
-  sign_protected: Uint8Array<ArrayBuffer>, // (should be empty)
-  external_aad: Uint8Array<ArrayBuffer>,
-  payload: Uint8Array<ArrayBuffer>,
+  body_protected: Uint8Array_,
+  sign_protected: Uint8Array_, // (should be empty)
+  external_aad: Uint8Array_,
+  payload: Uint8Array_,
 ];
 
 /**
@@ -203,9 +204,9 @@ export type COSESign1SigStructure = [
  */
 export type MdocCOSESign1SigStructure = [
   context: 'Signature1',
-  body_protected: Uint8Array<ArrayBuffer>,
-  sign_protected: Uint8Array<ArrayBuffer>, // (should be empty)
-  payload: Uint8Array<ArrayBuffer>,
+  body_protected: Uint8Array_,
+  sign_protected: Uint8Array_, // (should be empty)
+  payload: Uint8Array_,
 ];
 
 /**
@@ -214,5 +215,5 @@ export type MdocCOSESign1SigStructure = [
 export type DCAPIOID4VPSessionTranscript = [
   deviceEngagementBytes: null,
   eReaderKeyBytes: null,
-  handover: ['OpenID4VPDCAPIHandover', Uint8Array<ArrayBuffer>],
+  handover: ['OpenID4VPDCAPIHandover', Uint8Array_],
 ];

--- a/packages/server/src/formats/mdoc/types.ts
+++ b/packages/server/src/formats/mdoc/types.ts
@@ -66,7 +66,7 @@ export type IssuerAuth = COSESign1<
   MobileSecurityObjectBytes
 >;
 
-export type MdocIssuerAuthProtectedBytes = Uint8Array;
+export type MdocIssuerAuthProtectedBytes = Uint8Array<ArrayBuffer>;
 export type MdocIssuerAuthProtected = {
   /**
    * From mdoc 9.1.3.6:
@@ -79,7 +79,7 @@ export type MdocIssuerAuthProtected = {
   ): COSEALG.ES256 | COSEALG.ES384 | COSEALG.ES512 | COSEALG.EdDSA;
 };
 
-export type MdocDeviceAuthProtectedBytes = Uint8Array;
+export type MdocDeviceAuthProtectedBytes = Uint8Array<ArrayBuffer>;
 export type MdocDeviceAuthProtected = {
   /**
    * From mdoc 9.1.3.6:
@@ -92,7 +92,7 @@ export type MdocDeviceAuthProtected = {
   ): COSEALG.ES256 | COSEALG.ES384 | COSEALG.ES512 | COSEALG.EdDSA;
 };
 
-export type MobileSecurityObjectBytes = Uint8Array;
+export type MobileSecurityObjectBytes = Uint8Array<ArrayBuffer>;
 export type MobileSecurityObject = {
   get(key: 'version'): string; // Version of the MobileSecurityObject
   get(key: 'digestAlgorithm'): 'SHA-256' | 'SHA-384' | 'SHA-512'; // Message digest algorithm used
@@ -108,7 +108,7 @@ export type ValidityInfo = {
   get(key: 'validUntil'): CBORTag;
 };
 
-export type ValueDigests = Map<string, Map<number, Uint8Array>>;
+export type ValueDigests = Map<string, Map<number, Uint8Array<ArrayBuffer>>>;
 
 /**  */
 export type DeviceKeyInfo = {
@@ -127,7 +127,7 @@ export type AuthorizedDataElements = unknown; // Spec type: `{+ NameSpace => Dat
 
 export type DecodedIssuerSignedItem = {
   get(key: 'digestID'): number;
-  get(key: 'random'): Uint8Array;
+  get(key: 'random'): Uint8Array<ArrayBuffer>;
   get(key: 'elementIdentifier'): string;
   get(key: 'elementValue'): unknown; // Necessarily undefinable here
 };
@@ -175,8 +175,8 @@ export type COSESign1<
 ];
 export type COSESign1HeaderProtected = CBORType;
 export type COSESign1HeaderUnprotected = Map<string | number, CBORType>;
-export type COSESign1Payload = Uint8Array | undefined;
-export type COSESign1Signature = Uint8Array;
+export type COSESign1Payload = Uint8Array<ArrayBuffer> | undefined;
+export type COSESign1Signature = Uint8Array<ArrayBuffer>;
 
 /**
  * Sig_structure
@@ -190,10 +190,10 @@ export type COSESign1Signature = Uint8Array;
  */
 export type COSESign1SigStructure = [
   context: 'Signature1',
-  body_protected: Uint8Array,
-  sign_protected: Uint8Array, // (should be empty)
-  external_aad: Uint8Array,
-  payload: Uint8Array,
+  body_protected: Uint8Array<ArrayBuffer>,
+  sign_protected: Uint8Array<ArrayBuffer>, // (should be empty)
+  external_aad: Uint8Array<ArrayBuffer>,
+  payload: Uint8Array<ArrayBuffer>,
 ];
 
 /**
@@ -203,9 +203,9 @@ export type COSESign1SigStructure = [
  */
 export type MdocCOSESign1SigStructure = [
   context: 'Signature1',
-  body_protected: Uint8Array,
-  sign_protected: Uint8Array, // (should be empty)
-  payload: Uint8Array,
+  body_protected: Uint8Array<ArrayBuffer>,
+  sign_protected: Uint8Array<ArrayBuffer>, // (should be empty)
+  payload: Uint8Array<ArrayBuffer>,
 ];
 
 /**
@@ -214,5 +214,5 @@ export type MdocCOSESign1SigStructure = [
 export type DCAPIOID4VPSessionTranscript = [
   deviceEngagementBytes: null,
   eReaderKeyBytes: null,
-  handover: ['OpenID4VPDCAPIHandover', Uint8Array],
+  handover: ['OpenID4VPDCAPIHandover', Uint8Array<ArrayBuffer>],
 ];

--- a/packages/server/src/formats/mdoc/verifyDeviceSigned.ts
+++ b/packages/server/src/formats/mdoc/verifyDeviceSigned.ts
@@ -11,6 +11,7 @@ import type {
   MobileSecurityObject,
 } from './types.ts';
 import { SimpleDigiCredsError } from '../../helpers/simpleDigiCredsError.ts';
+import type { Uint8Array_ } from '../../helpers/types.ts';
 
 export async function verifyDeviceSigned(
   document: DecodedDocument,
@@ -23,7 +24,7 @@ export async function verifyDeviceSigned(
   // These bytes were provably signed above during IssuerAuth verification
   const decodedMSOBytes = decodeCBOR(issuerAuth[2]) as CBORTag;
   const decodedMSO = decodeCBOR(
-    decodedMSOBytes.value as Uint8Array<ArrayBuffer>,
+    decodedMSOBytes.value as Uint8Array_,
   ) as MobileSecurityObject;
 
   // Make sure the credential is chronologically valid
@@ -67,7 +68,7 @@ export async function verifyDeviceSigned(
   const deviceAuthenticationCBOR = encodeCBOR(deviceAuthentication);
   const deviceAuthenticationCBORBstr = encodeCBOR(
     new CBORTag(24, deviceAuthenticationCBOR),
-  ) as Uint8Array<ArrayBuffer>;
+  ) as Uint8Array_;
 
   const deviceAuth = deviceSigned.get('deviceAuth');
   const deviceSignature = deviceAuth.get('deviceSignature');
@@ -99,7 +100,7 @@ export async function verifyDeviceSigned(
 
   const verified = await verifyEC2({
     cosePublicKey: devicePublicKey,
-    data: encodeCBOR(deviceData) as Uint8Array<ArrayBuffer>,
+    data: encodeCBOR(deviceData) as Uint8Array_,
     signature: deviceSignature[3],
     shaHashOverride: hashAlg,
   });

--- a/packages/server/src/formats/mdoc/verifyDeviceSigned.ts
+++ b/packages/server/src/formats/mdoc/verifyDeviceSigned.ts
@@ -23,9 +23,7 @@ export async function verifyDeviceSigned(
 
   // These bytes were provably signed above during IssuerAuth verification
   const decodedMSOBytes = decodeCBOR(issuerAuth[2]) as CBORTag;
-  const decodedMSO = decodeCBOR(
-    decodedMSOBytes.value as Uint8Array_,
-  ) as MobileSecurityObject;
+  const decodedMSO = decodeCBOR(decodedMSOBytes.value as Uint8Array_) as MobileSecurityObject;
 
   // Make sure the credential is chronologically valid
   const validityInfo = decodedMSO.get('validityInfo');

--- a/packages/server/src/formats/mdoc/verifyDeviceSigned.ts
+++ b/packages/server/src/formats/mdoc/verifyDeviceSigned.ts
@@ -22,7 +22,9 @@ export async function verifyDeviceSigned(
 
   // These bytes were provably signed above during IssuerAuth verification
   const decodedMSOBytes = decodeCBOR(issuerAuth[2]) as CBORTag;
-  const decodedMSO = decodeCBOR(decodedMSOBytes.value as Uint8Array) as MobileSecurityObject;
+  const decodedMSO = decodeCBOR(
+    decodedMSOBytes.value as Uint8Array<ArrayBuffer>,
+  ) as MobileSecurityObject;
 
   // Make sure the credential is chronologically valid
   const validityInfo = decodedMSO.get('validityInfo');
@@ -63,7 +65,9 @@ export async function verifyDeviceSigned(
     deviceSignedNameSpaces,
   ];
   const deviceAuthenticationCBOR = encodeCBOR(deviceAuthentication);
-  const deviceAuthenticationCBORBstr = encodeCBOR(new CBORTag(24, deviceAuthenticationCBOR));
+  const deviceAuthenticationCBORBstr = encodeCBOR(
+    new CBORTag(24, deviceAuthenticationCBOR),
+  ) as Uint8Array<ArrayBuffer>;
 
   const deviceAuth = deviceSigned.get('deviceAuth');
   const deviceSignature = deviceAuth.get('deviceSignature');
@@ -95,7 +99,7 @@ export async function verifyDeviceSigned(
 
   const verified = await verifyEC2({
     cosePublicKey: devicePublicKey,
-    data: encodeCBOR(deviceData),
+    data: encodeCBOR(deviceData) as Uint8Array<ArrayBuffer>,
     signature: deviceSignature[3],
     shaHashOverride: hashAlg,
   });

--- a/packages/server/src/formats/mdoc/verifyIssuerSigned.ts
+++ b/packages/server/src/formats/mdoc/verifyIssuerSigned.ts
@@ -13,8 +13,8 @@ export async function verifyIssuerSigned(document: DecodedDocument): Promise<Ver
   const issuerAuth = issuerSigned.get('issuerAuth');
 
   const x5chain = issuerAuth[1].get(COSEHEADER.X5CHAIN);
-  let leafCert: Uint8Array;
-  let _normalizedX5C: Uint8Array[];
+  let leafCert: Uint8Array<ArrayBuffer>;
+  let _normalizedX5C: Uint8Array<ArrayBuffer>[];
   if (x509.isX509Array(x5chain)) {
     leafCert = x5chain[0];
     _normalizedX5C = x5chain;
@@ -44,7 +44,7 @@ export async function verifyIssuerSigned(document: DecodedDocument): Promise<Ver
 
   const verified = await verifyEC2({
     cosePublicKey,
-    data: encodeCBOR(issuerData),
+    data: encodeCBOR(issuerData) as Uint8Array<ArrayBuffer>,
     signature: issuerAuth[3],
     shaHashOverride: hashAlg,
   });
@@ -54,5 +54,5 @@ export async function verifyIssuerSigned(document: DecodedDocument): Promise<Ver
 
 type VerifiedIssuerSigned = {
   verified: boolean;
-  x5chain: Uint8Array[];
+  x5chain: Uint8Array<ArrayBuffer>[];
 };

--- a/packages/server/src/formats/mdoc/verifyIssuerSigned.ts
+++ b/packages/server/src/formats/mdoc/verifyIssuerSigned.ts
@@ -2,6 +2,7 @@ import { decodeCBOR, encodeCBOR } from '@levischuck/tiny-cbor';
 
 import { COSEHEADER, COSEKEYS, isCOSEPublicKeyEC2 } from '../../cose.ts';
 import { SimpleDigiCredsError, verifyEC2, x509 } from '../../helpers/index.ts';
+import type { Uint8Array_ } from '../../helpers/types.ts';
 import type {
   DecodedDocument,
   MdocCOSESign1SigStructure,
@@ -13,8 +14,8 @@ export async function verifyIssuerSigned(document: DecodedDocument): Promise<Ver
   const issuerAuth = issuerSigned.get('issuerAuth');
 
   const x5chain = issuerAuth[1].get(COSEHEADER.X5CHAIN);
-  let leafCert: Uint8Array<ArrayBuffer>;
-  let _normalizedX5C: Uint8Array<ArrayBuffer>[];
+  let leafCert: Uint8Array_;
+  let _normalizedX5C: Uint8Array_[];
   if (x509.isX509Array(x5chain)) {
     leafCert = x5chain[0];
     _normalizedX5C = x5chain;
@@ -44,7 +45,7 @@ export async function verifyIssuerSigned(document: DecodedDocument): Promise<Ver
 
   const verified = await verifyEC2({
     cosePublicKey,
-    data: encodeCBOR(issuerData) as Uint8Array<ArrayBuffer>,
+    data: encodeCBOR(issuerData) as Uint8Array_,
     signature: issuerAuth[3],
     shaHashOverride: hashAlg,
   });
@@ -54,5 +55,5 @@ export async function verifyIssuerSigned(document: DecodedDocument): Promise<Ver
 
 type VerifiedIssuerSigned = {
   verified: boolean;
-  x5chain: Uint8Array<ArrayBuffer>[];
+  x5chain: Uint8Array_[];
 };

--- a/packages/server/src/formats/mdoc/verifyMdocPresentation.ts
+++ b/packages/server/src/formats/mdoc/verifyMdocPresentation.ts
@@ -6,12 +6,13 @@ import { verifyIssuerSigned } from './verifyIssuerSigned.ts';
 import { verifyDeviceSigned } from './verifyDeviceSigned.ts';
 import { type VerifiedNamespace, verifyNameSpaces } from './verifyNameSpaces.ts';
 import { convertX509BufferToPEM } from '../../helpers/x509/index.ts';
+import type { Uint8Array_ } from '../../helpers/types.ts';
 
 /**
  * Verify an mdoc presentation as returned through the DC API
  */
 export async function verifyMdocPresentation(
-  responseBytes: Uint8Array<ArrayBuffer>,
+  responseBytes: Uint8Array_,
   request: DCAPIRequestOID4VP,
 ): Promise<VerifiedMdocPresentation> {
   const decodedResponse = decodeCBOR(responseBytes) as DecodedCredentialResponse;

--- a/packages/server/src/formats/mdoc/verifyMdocPresentation.ts
+++ b/packages/server/src/formats/mdoc/verifyMdocPresentation.ts
@@ -11,7 +11,7 @@ import { convertX509BufferToPEM } from '../../helpers/x509/index.ts';
  * Verify an mdoc presentation as returned through the DC API
  */
 export async function verifyMdocPresentation(
-  responseBytes: Uint8Array,
+  responseBytes: Uint8Array<ArrayBuffer>,
   request: DCAPIRequestOID4VP,
 ): Promise<VerifiedMdocPresentation> {
   const decodedResponse = decodeCBOR(responseBytes) as DecodedCredentialResponse;

--- a/packages/server/src/formats/mdoc/verifyNameSpaces.ts
+++ b/packages/server/src/formats/mdoc/verifyNameSpaces.ts
@@ -3,6 +3,7 @@ import { type CBORTag, decodeCBOR, encodeCBOR } from '@levischuck/tiny-cbor';
 import type { DCAPIRequestOID4VP } from '../../dcapi.ts';
 import type { DecodedDocument, DecodedIssuerSignedItem, MobileSecurityObject } from './types.ts';
 import { SimpleDigiCredsError } from '../../helpers/simpleDigiCredsError.ts';
+import type { Uint8Array_ } from '../../helpers/types.ts';
 
 export async function verifyNameSpaces(
   document: DecodedDocument,
@@ -17,7 +18,7 @@ export async function verifyNameSpaces(
 
   const decodedMSOBytes = decodeCBOR(issuerAuth[2]) as CBORTag;
   const decodedMSO = decodeCBOR(
-    decodedMSOBytes.value as Uint8Array<ArrayBuffer>,
+    decodedMSOBytes.value as Uint8Array_,
   ) as MobileSecurityObject;
 
   const msoDigestAlg = decodedMSO.get('digestAlgorithm');
@@ -32,7 +33,7 @@ export async function verifyNameSpaces(
   for (const [dataElemID, dataElemValues] of issuerSignedNameSpaces.entries()) {
     for (const issuerSignedItemBytes of dataElemValues) {
       const decodedItem = decodeCBOR(
-        issuerSignedItemBytes.value as Uint8Array,
+        issuerSignedItemBytes.value as Uint8Array_,
       ) as DecodedIssuerSignedItem;
 
       const digestID = decodedItem.get('digestID');

--- a/packages/server/src/formats/mdoc/verifyNameSpaces.ts
+++ b/packages/server/src/formats/mdoc/verifyNameSpaces.ts
@@ -17,9 +17,7 @@ export async function verifyNameSpaces(
   const issuerAuth = issuerSigned.get('issuerAuth');
 
   const decodedMSOBytes = decodeCBOR(issuerAuth[2]) as CBORTag;
-  const decodedMSO = decodeCBOR(
-    decodedMSOBytes.value as Uint8Array_,
-  ) as MobileSecurityObject;
+  const decodedMSO = decodeCBOR(decodedMSOBytes.value as Uint8Array_) as MobileSecurityObject;
 
   const msoDigestAlg = decodedMSO.get('digestAlgorithm');
 

--- a/packages/server/src/formats/mdoc/verifyNameSpaces.ts
+++ b/packages/server/src/formats/mdoc/verifyNameSpaces.ts
@@ -16,7 +16,9 @@ export async function verifyNameSpaces(
   const issuerAuth = issuerSigned.get('issuerAuth');
 
   const decodedMSOBytes = decodeCBOR(issuerAuth[2]) as CBORTag;
-  const decodedMSO = decodeCBOR(decodedMSOBytes.value as Uint8Array) as MobileSecurityObject;
+  const decodedMSO = decodeCBOR(
+    decodedMSOBytes.value as Uint8Array<ArrayBuffer>,
+  ) as MobileSecurityObject;
 
   const msoDigestAlg = decodedMSO.get('digestAlgorithm');
 

--- a/packages/server/src/helpers/base64url.ts
+++ b/packages/server/src/helpers/base64url.ts
@@ -1,18 +1,20 @@
 import * as base64 from '@hexagon/base64';
 
-export function bufferToBase64URL(buffer: Uint8Array<ArrayBuffer>): string {
+import type { Uint8Array_ } from './types.ts';
+
+export function bufferToBase64URL(buffer: Uint8Array_): string {
   return base64.fromArrayBuffer(buffer.buffer, true);
 }
 
-export function bufferToBase64(buffer: Uint8Array<ArrayBuffer>): string {
+export function bufferToBase64(buffer: Uint8Array_): string {
   return base64.fromArrayBuffer(buffer.buffer, false);
 }
 
-export function base64URLToBuffer(val: string): Uint8Array<ArrayBuffer> {
+export function base64URLToBuffer(val: string): Uint8Array_ {
   return new Uint8Array(base64.toArrayBuffer(val, true));
 }
 
-export function base64ToBuffer(val: string): Uint8Array<ArrayBuffer> {
+export function base64ToBuffer(val: string): Uint8Array_ {
   return new Uint8Array(base64.toArrayBuffer(val, false));
 }
 

--- a/packages/server/src/helpers/base64url.ts
+++ b/packages/server/src/helpers/base64url.ts
@@ -1,18 +1,18 @@
 import * as base64 from '@hexagon/base64';
 
-export function bufferToBase64URL(buffer: ArrayBuffer): string {
-  return base64.fromArrayBuffer(new Uint8Array(buffer), true);
+export function bufferToBase64URL(buffer: Uint8Array<ArrayBuffer>): string {
+  return base64.fromArrayBuffer(buffer.buffer, true);
 }
 
-export function bufferToBase64(buffer: ArrayBuffer): string {
-  return base64.fromArrayBuffer(new Uint8Array(buffer), false);
+export function bufferToBase64(buffer: Uint8Array<ArrayBuffer>): string {
+  return base64.fromArrayBuffer(buffer.buffer, false);
 }
 
-export function base64URLToBuffer(val: string): Uint8Array {
+export function base64URLToBuffer(val: string): Uint8Array<ArrayBuffer> {
   return new Uint8Array(base64.toArrayBuffer(val, true));
 }
 
-export function base64ToBuffer(val: string): Uint8Array {
+export function base64ToBuffer(val: string): Uint8Array<ArrayBuffer> {
   return new Uint8Array(base64.toArrayBuffer(val, false));
 }
 

--- a/packages/server/src/helpers/types.ts
+++ b/packages/server/src/helpers/types.ts
@@ -5,3 +5,19 @@ export type SubtleCryptoKeyAlgName =
   | 'Ed25519'
   | 'RSASSA-PKCS1-v1_5'
   | 'RSA-PSS';
+
+/**
+ * Equivalent to `Uint8Array` before TypeScript 5.7, and `Uint8Array<ArrayBuffer>` in TypeScript 5.7
+ * and beyond.
+ *
+ * **Context**
+ *
+ * `Uint8Array` became a generic type in TypeScript 5.7, requiring types defined simply as
+ * `Uint8Array` to be refactored to `Uint8Array<ArrayBuffer>` starting in Deno 2.2. `Uint8Array` is
+ * _not_ generic in Deno 2.1.x and earlier, though, so this type helps bridge this gap.
+ *
+ * Inspired by Deno's std library:
+ *
+ * https://github.com/denoland/std/blob/b5a5fe4f96b91c1fe8dba5cc0270092dd11d3287/bytes/_types.ts#L11
+ */
+export type Uint8Array_ = ReturnType<Uint8Array['slice']>;

--- a/packages/server/src/helpers/verifyEC2.ts
+++ b/packages/server/src/helpers/verifyEC2.ts
@@ -8,8 +8,8 @@ import type { SubtleCryptoAlg, SubtleCryptoCrv } from './types.ts';
  */
 export async function verifyEC2(opts: {
   cosePublicKey: COSEPublicKeyEC2;
-  signature: Uint8Array;
-  data: Uint8Array;
+  signature: Uint8Array<ArrayBuffer>;
+  data: Uint8Array<ArrayBuffer>;
   shaHashOverride?: COSEALG;
 }): Promise<boolean> {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;

--- a/packages/server/src/helpers/verifyEC2.ts
+++ b/packages/server/src/helpers/verifyEC2.ts
@@ -1,15 +1,15 @@
 import { type COSEALG, COSECRV, COSEKEYS, type COSEPublicKeyEC2 } from '../cose.ts';
 import { mapCoseAlgToWebCryptoAlg } from './mapCoseAlgToWebCryptoAlg.ts';
 import { base64url, importKey } from './index.ts';
-import type { SubtleCryptoAlg, SubtleCryptoCrv } from './types.ts';
+import type { SubtleCryptoAlg, SubtleCryptoCrv, Uint8Array_ } from './types.ts';
 
 /**
  * Verify a signature using an EC2 public key
  */
 export async function verifyEC2(opts: {
   cosePublicKey: COSEPublicKeyEC2;
-  signature: Uint8Array<ArrayBuffer>;
-  data: Uint8Array<ArrayBuffer>;
+  signature: Uint8Array_;
+  data: Uint8Array_;
   shaHashOverride?: COSEALG;
 }): Promise<boolean> {
   const { cosePublicKey, signature, data, shaHashOverride } = opts;

--- a/packages/server/src/helpers/x509/convertX509BufferToPEM.ts
+++ b/packages/server/src/helpers/x509/convertX509BufferToPEM.ts
@@ -1,9 +1,10 @@
 import { base64url } from '../index.ts';
+import type { Uint8Array_ } from '../types.ts';
 
 /**
  * Convert buffer to an OpenSSL-compatible PEM text format.
  */
-export function convertX509BufferToPEM(certBuffer: Uint8Array<ArrayBuffer>): string {
+export function convertX509BufferToPEM(certBuffer: Uint8Array_): string {
   // We specifically do not want base64url used here, PEM is base64
   const b64cert = base64url.bufferToBase64(certBuffer);
 

--- a/packages/server/src/helpers/x509/convertX509BufferToPEM.ts
+++ b/packages/server/src/helpers/x509/convertX509BufferToPEM.ts
@@ -3,7 +3,7 @@ import { base64url } from '../index.ts';
 /**
  * Convert buffer to an OpenSSL-compatible PEM text format.
  */
-export function convertX509BufferToPEM(certBuffer: Uint8Array): string {
+export function convertX509BufferToPEM(certBuffer: Uint8Array<ArrayBuffer>): string {
   // We specifically do not want base64url used here, PEM is base64
   const b64cert = base64url.bufferToBase64(certBuffer);
 

--- a/packages/server/src/helpers/x509/convertX509PublicKeyToCOSE.ts
+++ b/packages/server/src/helpers/x509/convertX509PublicKeyToCOSE.ts
@@ -13,7 +13,9 @@ import { RSAPublicKey } from '@peculiar/asn1-rsa';
 
 import { mapX509SignatureAlgToCOSEAlg } from './mapX509SignatureAlgToCOSEAlg.ts';
 
-export function convertX509PublicKeyToCOSE(x509Certificate: Uint8Array): COSEPublicKey {
+export function convertX509PublicKeyToCOSE(
+  x509Certificate: Uint8Array<ArrayBuffer>,
+): COSEPublicKey {
   let cosePublicKey: COSEPublicKey = new Map();
 
   /**
@@ -57,8 +59,8 @@ export function convertX509PublicKeyToCOSE(x509Certificate: Uint8Array): COSEPub
       subjectPublicKeyInfo.subjectPublicKey,
     );
 
-    let x: Uint8Array;
-    let y: Uint8Array;
+    let x: Uint8Array<ArrayBuffer>;
+    let y: Uint8Array<ArrayBuffer>;
     if (subjectPublicKey[0] === 0x04) {
       // Public key is in "uncompressed form", so we can split the remaining bytes in half
       let pointer = 1;

--- a/packages/server/src/helpers/x509/convertX509PublicKeyToCOSE.ts
+++ b/packages/server/src/helpers/x509/convertX509PublicKeyToCOSE.ts
@@ -1,6 +1,8 @@
 import { AsnParser } from '@peculiar/asn1-schema';
 import { Certificate } from '@peculiar/asn1-x509';
 import { ECParameters, id_ecPublicKey, id_secp256r1, id_secp384r1 } from '@peculiar/asn1-ecc';
+import { RSAPublicKey } from '@peculiar/asn1-rsa';
+
 import {
   COSECRV,
   COSEKEYS,
@@ -9,12 +11,11 @@ import {
   type COSEPublicKeyEC2,
   type COSEPublicKeyRSA,
 } from '../../cose.ts';
-import { RSAPublicKey } from '@peculiar/asn1-rsa';
-
 import { mapX509SignatureAlgToCOSEAlg } from './mapX509SignatureAlgToCOSEAlg.ts';
+import type { Uint8Array_ } from '../types.ts';
 
 export function convertX509PublicKeyToCOSE(
-  x509Certificate: Uint8Array<ArrayBuffer>,
+  x509Certificate: Uint8Array_,
 ): COSEPublicKey {
   let cosePublicKey: COSEPublicKey = new Map();
 
@@ -59,8 +60,8 @@ export function convertX509PublicKeyToCOSE(
       subjectPublicKeyInfo.subjectPublicKey,
     );
 
-    let x: Uint8Array<ArrayBuffer>;
-    let y: Uint8Array<ArrayBuffer>;
+    let x: Uint8Array_;
+    let y: Uint8Array_;
     if (subjectPublicKey[0] === 0x04) {
       // Public key is in "uncompressed form", so we can split the remaining bytes in half
       let pointer = 1;

--- a/packages/server/src/helpers/x509/getX509CertificateInfo.ts
+++ b/packages/server/src/helpers/x509/getX509CertificateInfo.ts
@@ -1,6 +1,8 @@
 import { AsnParser } from '@peculiar/asn1-schema';
 import { BasicConstraints, Certificate, id_ce_basicConstraints } from '@peculiar/asn1-x509';
 
+import type { Uint8Array_ } from '../types.ts';
+
 export type CertificateInfo = {
   issuer: Issuer;
   subject: Subject;
@@ -40,7 +42,7 @@ const issuerSubjectIDKey: { [key: string]: 'C' | 'O' | 'OU' | 'CN' } = {
  * @param pemCertificate Result from call to `convertASN1toPEM(x5c[0])`
  */
 export function getX509CertificateInfo(
-  leafCertBuffer: Uint8Array<ArrayBuffer>,
+  leafCertBuffer: Uint8Array_,
 ): CertificateInfo {
   const x509 = AsnParser.parse(leafCertBuffer, Certificate);
   const parsedCert = x509.tbsCertificate;

--- a/packages/server/src/helpers/x509/getX509CertificateInfo.ts
+++ b/packages/server/src/helpers/x509/getX509CertificateInfo.ts
@@ -40,7 +40,7 @@ const issuerSubjectIDKey: { [key: string]: 'C' | 'O' | 'OU' | 'CN' } = {
  * @param pemCertificate Result from call to `convertASN1toPEM(x5c[0])`
  */
 export function getX509CertificateInfo(
-  leafCertBuffer: Uint8Array,
+  leafCertBuffer: Uint8Array<ArrayBuffer>,
 ): CertificateInfo {
   const x509 = AsnParser.parse(leafCertBuffer, Certificate);
   const parsedCert = x509.tbsCertificate;

--- a/packages/server/src/helpers/x509/isX509Array.ts
+++ b/packages/server/src/helpers/x509/isX509Array.ts
@@ -1,3 +1,5 @@
-export function isX509Array(x5chain: Uint8Array | Uint8Array[]): x5chain is Uint8Array[] {
+export function isX509Array(
+  x5chain: Uint8Array<ArrayBuffer> | Uint8Array<ArrayBuffer>[],
+): x5chain is Uint8Array<ArrayBuffer>[] {
   return Array.isArray(x5chain);
 }

--- a/packages/server/src/helpers/x509/isX509Array.ts
+++ b/packages/server/src/helpers/x509/isX509Array.ts
@@ -1,5 +1,5 @@
-export function isX509Array(
-  x5chain: Uint8Array<ArrayBuffer> | Uint8Array<ArrayBuffer>[],
-): x5chain is Uint8Array<ArrayBuffer>[] {
+import type { Uint8Array_ } from '../types.ts';
+
+export function isX509Array(x5chain: Uint8Array_ | Uint8Array_[]): x5chain is Uint8Array_[] {
   return Array.isArray(x5chain);
 }


### PR DESCRIPTION
In upgrading locally to Deno v2.2.9 I experienced many errors on my many references to `Uint8Array`. It turns out in TypeScript 5.7, which Deno 2.2 uses, `Uint8Array` is now of type `Uint8Array<ArrayBufferLike>`. But while the solution in Deno 2.2 is to refactor these types to `Uint8Array<ArrayBuffer>`, `Uint8Array` is not generic before Deno 2.2 and so these types will error out.

To bridge this divide I took a page out of Deno's std library and introduced a `Uint8Array_` type that uses TS's vast powers to create a type that looks mostly like `Uint8Array` while supporting both Deno 2.1 and earlier, as well as Deno 2.2+.

I also added Deno 2.2 testing to CI for good measure.